### PR TITLE
added missing commands for cover page

### DIFF
--- a/settings/commands.tex
+++ b/settings/commands.tex
@@ -10,4 +10,10 @@
 \newcommand*{\getSubmissionDate}{TODO: Submission date}
 \newcommand*{\getSubmissionLocation}{Munich}
 
+%commands for cover page
+\newcommand*{\coverpageleftmargin}{%
+  \dimexpr \evensidemargin+1in\relax
+}
+\newcommand*{\coverpagerightmargin}{\coverpageleftmargin}
+
 % TODO: add custom commands etc.


### PR DESCRIPTION
Added the definitions for \coverpageleftmargin and \coverpagerightmargin as found in  http://mirrors.ctan.org/macros/latex/contrib/koma-script/scrkernel-title.dtx . Before the commands were undefined and caused build errors.
