### PR TITLE
removed warning destination with same identifier and added tex root

### DIFF
--- a/chapters/01_introduction.tex
+++ b/chapters/01_introduction.tex
@@ -1,3 +1,5 @@
+%!TEX root = ../main.tex
+% Add the above root in every chapter added for compiling the tex file easily.
 \chapter{Introduction}\label{chapter:introduction}
 
 \section{Section}

--- a/main.tex
+++ b/main.tex
@@ -14,6 +14,8 @@
 
 \begin{document}
 
+%https://en.wikibooks.org/wiki/LaTeX/Hyperlinks#Problems_with_Links_and_Pages
+\pagenumbering{alph}
 \input{pages/cover}
 
 \frontmatter{}


### PR DESCRIPTION
- Latexmk was always giving the following warning after compilation:

        destination with the same identifier (name{page.1}) has been already used, duplicate ignored
So wanted to make compile output clean.

- TEX Root has been added in the head of chapters, to make it easy to compile from chapter node.