### PR TITLE
Add TUM (TeX) Logo From Chair11 & Use ShareLaTeX CI

### DIFF
--- a/.latex.yml
+++ b/.latex.yml
@@ -1,0 +1,2 @@
+compiler: xelatex
+root_file: main.tex

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LaTeX template for TUM theses
 
+[![PDF Status](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/badge.svg)](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/output.pdf)
+
 This is a LaTeX template created according to the guidelines for TUM informatics theses in SS 2013. **Always check the [current formatting guidelines][thesis-guidelines] before you hand in.** See [`build/main.pdf`][sample-pdf] for an example PDF created with this template.
 
 Note: Because of copyright considerations, TUM logos are not included in this template and have to be downloaded separately (see instructions below).

--- a/logos/tumlogo.sty
+++ b/logos/tumlogo.sty
@@ -1,0 +1,61 @@
+% This is tumlogo.tex
+%
+% Neues TUM-Logo in TeX
+%   by G. Teege, 19.10.89
+% Benutzung:
+%   Am Anfang des Dokuments (TeX oder LaTeX):
+%     \input tumlogo
+%   Dann beliebig oft:
+%     \TUM{<breite>}
+%   bzw.
+%     \oTUM{<breite>}
+%   \TUM setzt das Logo mit der Breite <breite> und der entsprechenden Hoehe.
+%   <breite> muss eine <dimen> sein. \oTUM erzeugt eine "outline"-Version
+%   des Logos, d.h. weiss mit schwarzem Rand. Bei \TUM ist es ganz schwarz.
+%   \oTUM entspricht damit der offiziellen Version des Logos.
+%   Das Logo kann wie ein einzelnes Zeichen verwendet werden.
+%   Beispiel:
+%     Dies ist das TUM-Logo: \oTUM{1cm}.
+%
+\def\TUM#1{%
+\dimen1=#1\dimen1=.1143\dimen1%
+\dimen2=#1\dimen2=.419\dimen2%
+\dimen3=#1\dimen3=.0857\dimen3%
+\dimen4=\dimen1\advance\dimen4 by\dimen2%
+\setbox0=\vbox{\hrule width\dimen3 height\dimen1 depth0pt\vskip\dimen2}%
+\setbox1=\vbox{\hrule width\dimen1 height\dimen4 depth0pt}%
+\setbox2=\vbox{\hrule width\dimen3 height\dimen1 depth0pt}%
+\setbox3=\hbox{\copy0\copy1\copy0\copy1\box2\copy1\copy0\copy1\box0\box1}%
+\leavevmode\vbox{\box3}}
+%
+\def\oTUM#1{%
+\dimen1=#1\dimen1=.1143\dimen1%
+\dimen2=#1\dimen2=.419\dimen2%
+\dimen3=#1\dimen3=.0857\dimen3%
+\dimen0=#1\dimen0=.018\dimen0%
+\dimen4=\dimen1\advance\dimen4 by-\dimen0%
+\setbox1=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\advance\dimen4 by\dimen2%
+\setbox8=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\advance\dimen4 by-\dimen2\advance\dimen4 by-\dimen0%
+\setbox4=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen1\advance\dimen4 by\dimen3%
+\setbox6=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen3\advance\dimen4 by\dimen0%
+\setbox9=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen1%
+\setbox7=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\dimen4=\dimen3%
+\setbox5=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by-\dimen0%
+\setbox2=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\dimen4=\dimen2\advance\dimen4 by\dimen0%
+\setbox3=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\setbox0=\vbox{\hbox{\box9\lower\dimen2\copy3\lower\dimen2\copy5%
+\lower\dimen2\copy3\box7}\kern-\dimen2\nointerlineskip%
+\hbox{\raise\dimen2\box1\raise\dimen2\box2\copy3\copy4\copy3%
+\raise\dimen2\copy5\copy3\box6\copy3\raise\dimen2\copy5\copy3\copy4\copy3%
+\raise\dimen2\box5\box3\box4\box8}}%
+\leavevmode\box0}
+% End of tumlogo.tex
+

--- a/logos/tumlogo.tex
+++ b/logos/tumlogo.tex
@@ -1,0 +1,61 @@
+% This is tumlogo.tex
+%
+% Neues TUM-Logo in TeX
+%   by G. Teege, 19.10.89
+% Benutzung:
+%   Am Anfang des Dokuments (TeX oder LaTeX):
+%     \input tumlogo
+%   Dann beliebig oft:
+%     \TUM{<breite>}
+%   bzw.
+%     \oTUM{<breite>}
+%   \TUM setzt das Logo mit der Breite <breite> und der entsprechenden Hoehe.
+%   <breite> muss eine <dimen> sein. \oTUM erzeugt eine "outline"-Version
+%   des Logos, d.h. weiss mit schwarzem Rand. Bei \TUM ist es ganz schwarz.
+%   \oTUM entspricht damit der offiziellen Version des Logos.
+%   Das Logo kann wie ein einzelnes Zeichen verwendet werden.
+%   Beispiel:
+%     Dies ist das TUM-Logo: \oTUM{1cm}.
+%
+\def\TUM#1{%
+\dimen1=#1\dimen1=.1143\dimen1%
+\dimen2=#1\dimen2=.419\dimen2%
+\dimen3=#1\dimen3=.0857\dimen3%
+\dimen4=\dimen1\advance\dimen4 by\dimen2%
+\setbox0=\vbox{\hrule width\dimen3 height\dimen1 depth0pt\vskip\dimen2}%
+\setbox1=\vbox{\hrule width\dimen1 height\dimen4 depth0pt}%
+\setbox2=\vbox{\hrule width\dimen3 height\dimen1 depth0pt}%
+\setbox3=\hbox{\copy0\copy1\copy0\copy1\box2\copy1\copy0\copy1\box0\box1}%
+\leavevmode\vbox{\box3}}
+%
+\def\oTUM#1{%
+\dimen1=#1\dimen1=.1143\dimen1%
+\dimen2=#1\dimen2=.419\dimen2%
+\dimen3=#1\dimen3=.0857\dimen3%
+\dimen0=#1\dimen0=.018\dimen0%
+\dimen4=\dimen1\advance\dimen4 by-\dimen0%
+\setbox1=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\advance\dimen4 by\dimen2%
+\setbox8=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\advance\dimen4 by-\dimen2\advance\dimen4 by-\dimen0%
+\setbox4=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen1\advance\dimen4 by\dimen3%
+\setbox6=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen3\advance\dimen4 by\dimen0%
+\setbox9=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by\dimen1%
+\setbox7=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\dimen4=\dimen3%
+\setbox5=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\advance\dimen4 by-\dimen0%
+\setbox2=\vbox{\hrule width\dimen4 height\dimen0 depth0pt}%
+\dimen4=\dimen2\advance\dimen4 by\dimen0%
+\setbox3=\vbox{\hrule width\dimen0 height\dimen4 depth0pt}%
+\setbox0=\vbox{\hbox{\box9\lower\dimen2\copy3\lower\dimen2\copy5%
+\lower\dimen2\copy3\box7}\kern-\dimen2\nointerlineskip%
+\hbox{\raise\dimen2\box1\raise\dimen2\box2\copy3\copy4\copy3%
+\raise\dimen2\copy5\copy3\box6\copy3\raise\dimen2\copy5\copy3\copy4\copy3%
+\raise\dimen2\box5\box3\box4\box8}}%
+\leavevmode\box0}
+% End of tumlogo.tex
+

--- a/main.tex
+++ b/main.tex
@@ -19,6 +19,10 @@
 \newcommand*{\getSubmissionDate}{Submission date}
 \newcommand*{\getSubmissionLocation}{Munich}
 
+% TUM Logo
+% (Taken from http://www11.in.tum.de/lehre/thesis/latex)
+\input{logos/tumlogo}
+
 \begin{document}
 
 % Set page numbering to avoid "destination with the same identifier has been already used" warning for cover page.

--- a/pages/cover.tex
+++ b/pages/cover.tex
@@ -12,7 +12,7 @@
   \IfFileExists{logos/tum.pdf}{%
     \includegraphics[height=20mm]{logos/tum.pdf}
   }{%
-    \vspace*{20mm}
+    \oTUM{6.0cm}
   }
 
   \vspace{5mm}

--- a/pages/title.tex
+++ b/pages/title.tex
@@ -4,7 +4,7 @@
   \IfFileExists{logos/tum.pdf}{%
     \includegraphics[height=20mm]{logos/tum.pdf}
   }{%
-    \vspace*{20mm}
+    \oTUM{6.0cm}
   }
 
   \vspace{5mm}


### PR DESCRIPTION
**Include TeX Version of TUM Logo** from Chair 11 (Group of Applied Informatics - Cooperative Systems) Thesis Template
http://www11.in.tum.de/lehre/thesis/latex

This will include a TeX Based TUM Outline Shape, if no Logo File is present.

Somehow fixes #14.

---

**Use ShareLaTeX CI**
Go to https://www.sharelatex.com/github/repos and enable Build for this Repo.

Status Badge:
[![PDF Status](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/badge.svg)](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/output.pdf)

```
[![PDF Status](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/badge.svg)](https://www.sharelatex.com/github/repos/fwalch/tum-thesis-latex/builds/latest/output.pdf)
```
