### PR TITLE
Acknowledgments: fixed heading style and hyperref

### DIFF
--- a/pages/acknowledgements.tex
+++ b/pages/acknowledgements.tex
@@ -1,10 +1,11 @@
+\phantomsection
 \addcontentsline{toc}{chapter}{Acknowledgments}
 \thispagestyle{empty}
 
 \vspace*{20mm}
 
 \begin{center}
-{\usekomafont{section} Acknowledgments}
+{\usekomafont{sectioning}\usekomafont{section} Acknowledgments}
 \end{center}
 
 \vspace{10mm}


### PR DESCRIPTION
fixed heading style (sectioning & section)
added \phantomsection for hyperref to correctly reference page in PDF