### PR TITLE
Add \par to title

### DIFF
--- a/pages/title.tex
+++ b/pages/title.tex
@@ -17,10 +17,10 @@
   {\Large \getDoctype{}}
 
   \vspace{15mm}
-  {\huge\bfseries \getTitle{}}
+  {\huge\bfseries \getTitle{} \par}
 
   \vspace{10mm}
-  {\huge\bfseries \foreignlanguage{ngerman}{\getTitleGer{}}}
+  {\huge\bfseries \foreignlanguage{ngerman}{\getTitleGer{}} \par}
 
   \vspace{15mm}
   \begin{tabular}{l l}


### PR DESCRIPTION
The \par improves the line spacing for multi-line titles.