### PR TITLE
Replace Faculty Name With School Name

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -9,7 +9,7 @@
 
 % TODO: change thesis information
 \newcommand*{\getUniversity}{Technische Universität München}
-\newcommand*{\getFaculty}{Department of Informatics}
+\newcommand*{\getFaculty}{School of Computation, Information and Technology --- Informatics}
 \newcommand*{\getTitle}{Thesis title}
 \newcommand*{\getTitleGer}{Titel der Abschlussarbeit}
 \newcommand*{\getAuthor}{Author}

--- a/pages/title.tex
+++ b/pages/title.tex
@@ -8,13 +8,13 @@
   }
 
   \vspace{5mm}
-  {\huge\MakeUppercase{\getFaculty{}}}\\
+  {\huge\MakeUppercase{\getFaculty{}} \par}
 
   \vspace{5mm}
-  {\large\MakeUppercase{\getUniversity{}}}\\
+  {\large\MakeUppercase{\getUniversity{}} \par}
 
   \vspace{20mm}
-  {\Large \getDoctype{}}
+  {\Large \getDoctype{} \par}
 
   \vspace{15mm}
   {\huge\bfseries \getTitle{} \par}


### PR DESCRIPTION
The information page on thesis formalities for the (former) department of informatics has been updated:

> Cover:
>
> - Technische Universität München or Technical University of Munich
> - **School of Computation, Information and Technology - Informatics**
> - Master's Thesis in | Bachelor's Thesis in Informatics | Informatics: Games Engineering | Information

Sure, not everyone using this template is even studying computer science, but it makes more sense than leaving an out-of-date default.

Also, replaced some new lines (`\\`) with uses of `\par` so that line spacing is properly applied to the new, longer title.
